### PR TITLE
Add empty nohoist key on package.json template

### DIFF
--- a/lib/plugins/base/template/package.json
+++ b/lib/plugins/base/template/package.json
@@ -11,7 +11,8 @@
   "workspaces": {
     "packages": [
       "packages/*"
-    ]
+    ],
+    "nohoist": []
   },
   "jest": {
     "roots": [

--- a/src/plugins/base/template/package.json
+++ b/src/plugins/base/template/package.json
@@ -11,7 +11,8 @@
   "workspaces": {
     "packages": [
       "packages/*"
-    ]
+    ],
+    "nohoist": []
   },
   "jest": {
     "roots": [


### PR DESCRIPTION
Fix #4 

Missing `nohoist` key cause ` TypeError: Cannot read property 'push' of undefined` error.